### PR TITLE
Add the ability for TextInput/PasswordInput fields to be required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,27 @@ Run `yarn publish-storybook` to deploy storybook on [gh-pages branch](https://pa
 ```sh
 yarn publish
 ```
+
+---
+
+## Dist on GitHub and reference in `package.json` directly from GitHub
+
+This is in case the pull request doesn't get accepted quickly.
+
+Fork to a separate branch so as not to polute master or others, e.g. `release/x.y.z`
+
+Build the `dist` files
+
+```
+npm run prepublish
+```
+
+Reference the tarball for the branch from your `package.json` file
+
+```
+ "dependencies": {
+   ...
+   "react-bootstrap-dialog": "https://github.com/dvdsmpsn/react-bootstrap-dialog/tarball/release/v0.12.1",
+   ...
+ }
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bootstrap-dialog",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "The modal-dialog React component with React Bootstrap, alternates `window.confirm` and `window.alert`.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bootstrap-dialog",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The modal-dialog React component with React Bootstrap, alternates `window.confirm` and `window.alert`.",
   "repository": {
     "type": "git",

--- a/src/PromptInput.js
+++ b/src/PromptInput.js
@@ -4,11 +4,12 @@ import {PasswordPrompt} from './Prompts'
 export default class PromptInput extends React.Component {
   constructor (props) {
     super(props)
-    const {initialValue, placeholder} = props.prompt
+    const {initialValue, placeholder, required} = props.prompt
     this.state = {
       value: initialValue || '',
       initialValue,
-      placeholder
+      placeholder,
+	  required
     }
     this.inputElement = null
     this.onSubmit = this.onSubmit.bind(this)
@@ -32,7 +33,7 @@ export default class PromptInput extends React.Component {
 
   render () {
     const {prompt} = this.props
-    const {value, placeholder} = this.state
+    const {value, placeholder,required} = this.state
     const type = (prompt instanceof PasswordPrompt) ? 'password' : 'text'
     return (
       <form onSubmit={this.onSubmit}>
@@ -44,6 +45,7 @@ export default class PromptInput extends React.Component {
           placeholder={placeholder}
           onChange={(e) => this.setState({value: e.target.value})}
           autoFocus
+		  required={required}
         />
       </form>
     )

--- a/src/Prompts.js
+++ b/src/Prompts.js
@@ -1,12 +1,12 @@
-
 /**
  * The class to represent prompt options
  */
 export class DialogPrompt {
   constructor (options = {}) {
-    const {initialValue, placeholder} = options
+    const {initialValue, placeholder, required} = options
     this.initialValue = initialValue
     this.placeholder = placeholder
+    this.required = required
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -212,7 +212,6 @@ class DialogAction {
   }
 
   func (dialog) {
-    dialog.hide()
     this._func && this._func(dialog)
   }
 }
@@ -228,7 +227,15 @@ Dialog.options = Dialog.DEFAULT_OPTIONS
 
 Dialog.Action = (label, func, className, key) => new DialogAction(label, func, className, key)
 Dialog.DefaultAction = (label, func, className) => new DialogAction(label, func, className && className.length > 0 ? className : Dialog.options.primaryClassName, 'enter')
-Dialog.OKAction = (func) => new DialogAction(Dialog.options.defaultOkLabel, (dialog) => { dialog.hide(); func && func(dialog) }, Dialog.options.primaryClassName, 'enter')
+Dialog.OKAction = (func) => new DialogAction(Dialog.options.defaultOkLabel, (dialog) => { 
+    if (!(dialog.state.prompt && dialog.state.prompt.required && dialog.value === '')) {
+      dialog.hide();
+    }  	
+    func && func(dialog) 
+  },
+  Dialog.options.primaryClassName,
+  'enter'
+)
 Dialog.CancelAction = (func) => new DialogAction(Dialog.options.defaultCancelLabel, (dialog) => { dialog.hide(); func && func(dialog) }, null, 'esc')
 Dialog.SingleOKAction = () => new DialogAction(Dialog.options.defaultOkLabel, (dialog) => { dialog.hide() }, Dialog.options.primaryClassName, 'enter,esc')
 

--- a/src/index.js
+++ b/src/index.js
@@ -146,10 +146,10 @@ class Dialog extends React.Component {
       }
     )
     return (
-      <Modal show={this.state.showModal} onHide={this.onHide} {...additionalProps}>
+      <Modal show={this.state.showModal} onHide={this.onHide} {...additionalProps} backdrop="static">
         {
           this.state.title && (
-            <Modal.Header>
+            <Modal.Header closeButton>
               <Modal.Title>
                 {this.state.title}
               </Modal.Title>

--- a/src/index.js
+++ b/src/index.js
@@ -147,15 +147,13 @@ class Dialog extends React.Component {
     )
     return (
       <Modal show={this.state.showModal} onHide={this.onHide} {...additionalProps} backdrop="static">
-        {
-          this.state.title && (
+
             <Modal.Header closeButton>
               <Modal.Title>
-                {this.state.title}
+                {this.state.title || ''}
               </Modal.Title>
             </Modal.Header>
-          )
-        }
+
         <Modal.Body>
           {
             typeof this.state.body === 'string'

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import React from 'react'
-import * as ReactBootstrap from 'react-bootstrap'
-import {TextPrompt, PasswordPrompt} from './Prompts'
-import PromptInput from './PromptInput'
+import React from "react";
+import * as ReactBootstrap from "react-bootstrap";
+import { TextPrompt, PasswordPrompt } from "./Prompts";
+import PromptInput from "./PromptInput";
 
-const Modal = ReactBootstrap.Modal
+const Modal = ReactBootstrap.Modal;
 
 /**
  * The modal dialog which can be altenative to `window.confirm` and `window.alert`.
@@ -16,18 +16,18 @@ class Dialog extends React.Component {
    * Set default options for applying to all dialogs.
    * @param options
    */
-  static setOptions (options) {
-    Dialog.options = Object.assign({}, Dialog.DEFAULT_OPTIONS, options)
+  static setOptions(options) {
+    Dialog.options = Object.assign({}, Dialog.DEFAULT_OPTIONS, options);
   }
 
   /**
    * Reset default options to presets.
    */
-  static resetOptions () {
-    Dialog.options = Dialog.DEFAULT_OPTIONS
+  static resetOptions() {
+    Dialog.options = Dialog.DEFAULT_OPTIONS;
   }
 
-  static initialState () {
+  static initialState() {
     return {
       title: null,
       body: null,
@@ -36,21 +36,21 @@ class Dialog extends React.Component {
       bsSize: undefined,
       onHide: null,
       prompt: null
-    }
+    };
   }
 
-  constructor (props) {
-    super(props)
-    this.promptInput = null
-    this.keyBinds = []
-    this.state = Dialog.initialState()
-    this.onHide = this.onHide.bind(this)
-    this.onSubmitPrompt = this.onSubmitPrompt.bind(this)
+  constructor(props) {
+    super(props);
+    this.promptInput = null;
+    this.keyBinds = [];
+    this.state = Dialog.initialState();
+    this.onHide = this.onHide.bind(this);
+    this.onSubmitPrompt = this.onSubmitPrompt.bind(this);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.state.showModal) {
-      this.hide()
+      this.hide();
     }
   }
 
@@ -64,21 +64,23 @@ class Dialog extends React.Component {
    * @param options.onHide {function} The method to call when the dialog was closed by clicking background.
    * @param options.prompt {[null, Prompt]} Use prompt for text input or password input.
    */
-  show (options = {}) {
-    let keyBinds = {}
-    let actions = options.actions || []
-    actions.forEach((action) => {
+  show(options = {}) {
+    let keyBinds = {};
+    let actions = options.actions || [];
+    actions.forEach(action => {
       if (action.key) {
-        action.key.split(',').forEach((key) => {
-          keyBinds[key] = () => { action.func && action.func(this) }
-        })
+        action.key.split(",").forEach(key => {
+          keyBinds[key] = () => {
+            action.func && action.func(this);
+          };
+        });
       }
-    })
+    });
     // TODO: Add keybinds
-    this.keyBinds = keyBinds
-    options['showModal'] = true
-    this.setState(Dialog.initialState())
-    this.setState(options)
+    this.keyBinds = keyBinds;
+    options["showModal"] = true;
+    this.setState(Dialog.initialState());
+    this.setState(options);
   }
 
   /**
@@ -86,108 +88,113 @@ class Dialog extends React.Component {
    * @param body The body of message.
    * @param bsSize {[null, 'medium', 'large', 'small']} The width size for dialog.
    */
-  showAlert (body, bsSize = undefined) {
+  showAlert(body, bsSize = undefined) {
     const options = {
       body: body,
-      actions: [
-        Dialog.SingleOKAction()
-      ],
+      actions: [Dialog.SingleOKAction()],
       bsSize: bsSize
-    }
-    this.show(options)
+    };
+    this.show(options);
   }
 
-  onHide () {
-    const onHide = this.state.onHide
-    if (typeof onHide === 'function') {
-      onHide(this)
+  onHide() {
+    const onHide = this.state.onHide;
+    if (typeof onHide === "function") {
+      onHide(this);
     } else {
-      this.hide()
+      this.hide();
     }
   }
 
   /**
    * Hide this dialog.
    */
-  hide () {
-    if (!this.state.showModal) return
+  hide() {
+    if (!this.state.showModal) return;
     // TODO: Remove keybinds
-    this.setState({showModal: false})
+    this.setState({ showModal: false });
   }
 
   /**
    * Get the value in prompt.
    * @return {string, null}
    */
-  get value () {
+  get value() {
     if (this.promptInput) {
-      return this.promptInput.value
+      return this.promptInput.value;
     }
-    return null
+    return null;
   }
 
-  onSubmitPrompt () {
-    const action = this.keyBinds['enter']
-    action && action()
+  onSubmitPrompt() {
+    const action = this.keyBinds["enter"];
+    action && action();
   }
 
-  getSize (defaultSize) {
-    return (typeof this.state.bsSize) === 'undefined' ? defaultSize : (this.state.bsSize === 'medium' ? null : this.state.bsSize)
+  getSize(defaultSize) {
+    return typeof this.state.bsSize === "undefined"
+      ? defaultSize
+      : this.state.bsSize === "medium"
+      ? null
+      : this.state.bsSize;
   }
 
-  render () {
+  render() {
     // XXX: Check current ReactBootstrap v4, or not.
-    const isLaterV4 = !!ReactBootstrap['Card']
-    const additionalProps = (
-      isLaterV4 ? {
-        size: this.getSize('sm')
-      } : {
-        bsSize: this.getSize('small')
-      }
-    )
+    const isLaterV4 = !!ReactBootstrap["Card"];
+    const additionalProps = isLaterV4
+      ? {
+          size: this.getSize("sm")
+        }
+      : {
+          bsSize: this.getSize("small")
+        };
     return (
-      <Modal show={this.state.showModal} onHide={this.onHide} {...additionalProps} backdrop="static">
-
-            <Modal.Header closeButton>
-              <Modal.Title>
-                {this.state.title || ''}
-              </Modal.Title>
-            </Modal.Header>
+      <Modal
+        show={this.state.showModal}
+        onHide={this.onHide}
+        {...additionalProps}
+        backdrop="static"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>{this.state.title || ""}</Modal.Title>
+        </Modal.Header>
 
         <Modal.Body>
-          {
-            typeof this.state.body === 'string'
-              ? (<p>{this.state.body}</p>)
-              : this.state.body
-          }
-          {
-            this.state.prompt && (
-              <PromptInput
-                ref={(el) => { this.promptInput = el }}
-                prompt={this.state.prompt}
-                onSubmit={this.onSubmitPrompt}
-              />
-            )
-          }
+          {typeof this.state.body === "string" ? (
+            <p>{this.state.body}</p>
+          ) : (
+            this.state.body
+          )}
+          {this.state.prompt && (
+            <PromptInput
+              ref={el => {
+                this.promptInput = el;
+              }}
+              prompt={this.state.prompt}
+              onSubmit={this.onSubmitPrompt}
+            />
+          )}
         </Modal.Body>
         <Modal.Footer>
-          {
-            this.state.actions.map((action, index) => {
-              return (
-                <button
-                  key={index}
-                  type='button'
-                  className={`btn btn-sm ${action.className}`}
-                  onClick={() => { action.func && action.func(this) }}
-                  style={{minWidth: 82}}>
-                  {action.label}
-                </button>
-              )
-            })
-          }
+          {this.state.actions.map((action, index) => {
+            return (
+              <button
+                key={index}
+                type="button"
+                className={`btn btn-sm ${action.className}`}
+                onClick={() => {
+                  action.func && action.func(this);
+                }}
+                style={{ minWidth: 82 }}
+              >
+                {action.label}
+              </button>
+            );
+          })}
         </Modal.Footer>
       </Modal>
-    )
+    );
   }
 }
 
@@ -202,43 +209,89 @@ class DialogAction {
    * @param func The function to execute when button is clicked. Default is null.
    * @param className The class name for button. Default is ''.
    */
-  constructor (label, func, className, key) {
-    this.label = label || Dialog.options.defaultOkLabel
-    this._func = func
-    this.className = className || Dialog.options.defaultButtonClassName
-    this.key = key
+  constructor(label, func, className, key) {
+    this.label = label || Dialog.options.defaultOkLabel;
+    this._func = func;
+    this.className = className || Dialog.options.defaultButtonClassName;
+    this.key = key;
   }
 
-  func (dialog) {
-    this._func && this._func(dialog)
+  func(dialog) {
+    this._func && this._func(dialog);
   }
 }
 
 Dialog.DEFAULT_OPTIONS = {
-  defaultOkLabel: 'OK',
-  defaultCancelLabel: 'Cancel',
-  primaryClassName: 'btn-primary',
-  defaultButtonClassName: 'btn-default btn-outline-secondary'
-}
+  defaultOkLabel: "OK",
+  defaultCancelLabel: "Cancel",
+  primaryClassName: "btn-primary",
+  defaultButtonClassName: "btn-default btn-outline-secondary"
+};
 
-Dialog.options = Dialog.DEFAULT_OPTIONS
+Dialog.options = Dialog.DEFAULT_OPTIONS;
 
-Dialog.Action = (label, func, className, key) => new DialogAction(label, (dialog) => { dialog.hide(); func && func(dialog)}, className, key)
-Dialog.DefaultAction = (label, func, className) => new DialogAction(label, (dialog) => { dialog.hide(); func && func(dialog)}, className && className.length > 0 ? className : Dialog.options.primaryClassName, 'enter')
-Dialog.OKAction = (func) => new DialogAction(Dialog.options.defaultOkLabel, (dialog) => { 
-    if (!(dialog.state.prompt && dialog.state.prompt.required && dialog.value === '')) {
+Dialog.Action = (label, func, className, key) =>
+  new DialogAction(
+    label,
+    dialog => {
       dialog.hide();
-    }  	
-    func && func(dialog) 
-  },
-  Dialog.options.primaryClassName,
-  'enter'
-)
-Dialog.CancelAction = (func) => new DialogAction(Dialog.options.defaultCancelLabel, (dialog) => { dialog.hide(); func && func(dialog) }, null, 'esc')
-Dialog.SingleOKAction = () => new DialogAction(Dialog.options.defaultOkLabel, (dialog) => { dialog.hide() }, Dialog.options.primaryClassName, 'enter,esc')
+      func && func(dialog);
+    },
+    className,
+    key
+  );
+Dialog.DefaultAction = (label, func, className) =>
+  new DialogAction(
+    label,
+    dialog => {
+      dialog.hide();
+      func && func(dialog);
+    },
+    className && className.length > 0
+      ? className
+      : Dialog.options.primaryClassName,
+    "enter"
+  );
+Dialog.OKAction = func =>
+  new DialogAction(
+    Dialog.options.defaultOkLabel,
+    dialog => {
+      if (
+        !(
+          dialog.state.prompt &&
+          dialog.state.prompt.required &&
+          dialog.value === ""
+        )
+      ) {
+        dialog.hide();
+      }
+      func && func(dialog);
+    },
+    Dialog.options.primaryClassName,
+    "enter"
+  );
+Dialog.CancelAction = func =>
+  new DialogAction(
+    Dialog.options.defaultCancelLabel,
+    dialog => {
+      dialog.hide();
+      func && func(dialog);
+    },
+    null,
+    "esc"
+  );
+Dialog.SingleOKAction = () =>
+  new DialogAction(
+    Dialog.options.defaultOkLabel,
+    dialog => {
+      dialog.hide();
+    },
+    Dialog.options.primaryClassName,
+    "enter,esc"
+  );
 
-Dialog.TextPrompt = (options) => new TextPrompt(options)
-Dialog.PasswordPrompt = (options) => new PasswordPrompt(options)
+Dialog.TextPrompt = options => new TextPrompt(options);
+Dialog.PasswordPrompt = options => new PasswordPrompt(options);
 
-Dialog.displayName = 'Dialog'
-module.exports = Dialog
+Dialog.displayName = "Dialog";
+module.exports = Dialog;

--- a/src/index.js
+++ b/src/index.js
@@ -225,8 +225,8 @@ Dialog.DEFAULT_OPTIONS = {
 
 Dialog.options = Dialog.DEFAULT_OPTIONS
 
-Dialog.Action = (label, func, className, key) => new DialogAction(label, func, className, key)
-Dialog.DefaultAction = (label, func, className) => new DialogAction(label, func, className && className.length > 0 ? className : Dialog.options.primaryClassName, 'enter')
+Dialog.Action = (label, func, className, key) => new DialogAction(label, (dialog) => { dialog.hide(); func && func(dialog)}, className, key)
+Dialog.DefaultAction = (label, func, className) => new DialogAction(label, (dialog) => { dialog.hide(); func && func(dialog)}, className && className.length > 0 ? className : Dialog.options.primaryClassName, 'enter')
 Dialog.OKAction = (func) => new DialogAction(Dialog.options.defaultOkLabel, (dialog) => { 
     if (!(dialog.state.prompt && dialog.state.prompt.required && dialog.value === '')) {
       dialog.hide();

--- a/src/stories/samples/ShowPrompt.js
+++ b/src/stories/samples/ShowPrompt.js
@@ -32,7 +32,7 @@ export default class ShowPrompt extends React.Component {
 
   showTextInputRequired () {
     this.dialog.show({
-      body: 'Input your message.',
+      body: 'Input your message (required).',
       prompt: Dialog.TextPrompt({required: true}),
       actions: [
         Dialog.CancelAction(),
@@ -60,7 +60,7 @@ export default class ShowPrompt extends React.Component {
 
   showTextInputWithOptionsRequired () {
     this.dialog.show({
-      body: 'Input your message.',
+      body: 'Input your message (required).',
       prompt: Dialog.TextPrompt({placeholder: 'name', required: true}),
       actions: [
         Dialog.CancelAction(),
@@ -88,7 +88,7 @@ export default class ShowPrompt extends React.Component {
 
   showPasswordInputRequired () {
     this.dialog.show({
-      body: 'Input your password.',
+      body: 'Input your password (required).',
       prompt: Dialog.PasswordPrompt({required: true}),
       actions: [
         Dialog.CancelAction(),
@@ -116,7 +116,7 @@ export default class ShowPrompt extends React.Component {
 
   showPasswordInputWithOptionsRequired () {
     this.dialog.show({
-      body: 'Input your password.',
+      body: 'Input your password (required).',
       prompt: Dialog.PasswordPrompt({placeholder: 'secret', required: true }),
       actions: [
         Dialog.CancelAction(),

--- a/src/stories/samples/ShowPrompt.js
+++ b/src/stories/samples/ShowPrompt.js
@@ -155,7 +155,7 @@ export default class ShowPrompt extends React.Component {
         </p>
 
         <p>
-          <Button onClick={this.showPasswordInputWithOptionsRequired}>Password inputt (required) with options</Button>
+          <Button onClick={this.showPasswordInputWithOptionsRequired}>Password input (required) with options</Button>
         </p>
 
         <Dialog ref={(el) => { this.dialog = el }} />

--- a/src/stories/samples/ShowPrompt.js
+++ b/src/stories/samples/ShowPrompt.js
@@ -7,15 +7,33 @@ export default class ShowPrompt extends React.Component {
   constructor () {
     super()
     this.showTextInput = this.showTextInput.bind(this)
+    this.showTextInputRequired = this.showTextInputRequired.bind(this)
     this.showTextInputWithOptions = this.showTextInputWithOptions.bind(this)
+    this.showTextInputWithOptionsRequired = this.showTextInputWithOptionsRequired.bind(this)
     this.showPasswordInput = this.showPasswordInput.bind(this)
+    this.showPasswordInputRequired = this.showPasswordInputRequired.bind(this)
     this.showPasswordInputWithOptions = this.showPasswordInputWithOptions.bind(this)
+    this.showPasswordInputWithOptionsRequired = this.showPasswordInputWithOptionsRequired.bind(this)
   }
 
   showTextInput () {
     this.dialog.show({
       body: 'Input your message.',
       prompt: Dialog.TextPrompt(),
+      actions: [
+        Dialog.CancelAction(),
+        Dialog.OKAction((dialog) => {
+          const result = dialog.value
+          action(`okay! result is "${result}".`)()
+        })
+      ]
+    })
+  }
+
+  showTextInputRequired () {
+    this.dialog.show({
+      body: 'Input your message.',
+      prompt: Dialog.TextPrompt({required: true}),
       actions: [
         Dialog.CancelAction(),
         Dialog.OKAction((dialog) => {
@@ -40,10 +58,38 @@ export default class ShowPrompt extends React.Component {
     })
   }
 
+  showTextInputWithOptionsRequired () {
+    this.dialog.show({
+      body: 'Input your message.',
+      prompt: Dialog.TextPrompt({placeholder: 'name', required: true}),
+      actions: [
+        Dialog.CancelAction(),
+        Dialog.OKAction((dialog) => {
+          const result = dialog.value
+          action(`okay! result is "${result}".`)()
+        })
+      ]
+    })
+  }
+
   showPasswordInput () {
     this.dialog.show({
       body: 'Input your password.',
       prompt: Dialog.PasswordPrompt(),
+      actions: [
+        Dialog.CancelAction(),
+        Dialog.OKAction((dialog) => {
+          const result = dialog.value
+          action(`okay! result is "${result}".`)()
+        })
+      ]
+    })
+  }
+
+  showPasswordInputRequired () {
+    this.dialog.show({
+      body: 'Input your password.',
+      prompt: Dialog.PasswordPrompt({required: true}),
       actions: [
         Dialog.CancelAction(),
         Dialog.OKAction((dialog) => {
@@ -68,6 +114,20 @@ export default class ShowPrompt extends React.Component {
     })
   }
 
+  showPasswordInputWithOptionsRequired () {
+    this.dialog.show({
+      body: 'Input your password.',
+      prompt: Dialog.PasswordPrompt({placeholder: 'secret', required: true }),
+      actions: [
+        Dialog.CancelAction(),
+        Dialog.OKAction((dialog) => {
+          const result = dialog.value
+          action(`okay! result is "${result}".`)()
+        })
+      ]
+    })
+  }
+
   render () {
     return (
       <div>
@@ -75,14 +135,27 @@ export default class ShowPrompt extends React.Component {
           <Button onClick={this.showTextInput}>Text input</Button>
         </p>
         <p>
+          <Button onClick={this.showTextInputRequired}>Text input (required)</Button>
+        </p>
+        <p>
           <Button onClick={this.showTextInputWithOptions}>Text input with options</Button>
+        </p>
+        <p>
+          <Button onClick={this.showTextInputWithOptionsRequired}>Text input (required) with options</Button>
         </p>
         <hr />
         <p>
           <Button onClick={this.showPasswordInput}>Password input</Button>
         </p>
         <p>
+          <Button onClick={this.showPasswordInputRequired}>Password input (required)</Button>
+        </p>
+        <p>
           <Button onClick={this.showPasswordInputWithOptions}>Password input with options</Button>
+        </p>
+
+        <p>
+          <Button onClick={this.showPasswordInputWithOptionsRequired}>Password inputt (required) with options</Button>
         </p>
 
         <Dialog ref={(el) => { this.dialog = el }} />


### PR DESCRIPTION
If the field is required and empty, then the dialog will not be hidden.

With this pull request, when you hit "Enter" on they keyboard, an empty, `TextInput`/`PasswordInput` the "Please fill in this field" bubble will appear, eg:

--- 

<img  src="https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Fjohn.foliot.ca%2Fwp-content%2Fuploads%2F2014%2F12%2Finput-required.jpg&f=1!">

--- 

Unfortunately, I haven't however been able to get this to appear when you click on the `Dialog.OKAction` button.