### PR TITLE
JSX element class does not support attributes because it does not have a 'props' property.ts(2607)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -240,7 +240,7 @@ export default class Dialog extends React.Component <Props, State> {
     return (typeof this.state.bsSize) === 'undefined' ? defaultSize : (this.state.bsSize === 'medium' ? null : this.state.bsSize)
   }
 
-  render () {
+  render (): React.ReactNode {
     const additionalProps = (
       isLaterV4 ? {
         size: this.getSize('sm')


### PR DESCRIPTION
I've recently had a problem using this library with TypeScript. 

It turns out that the typings that are automatically generated by tsc seem to be wrong  (for reasons beyond me).

The error can be seen https://codesandbox.io/s/react-bootstrap-dialog-p3mh3-p3mh3

This hopefully resolves that. 